### PR TITLE
hotfix: 그룹 상세 멤버수 오류 해결

### DIFF
--- a/adapter-out/rdb/src/main/kotlin/com/yapp/bol/group/member/MemberQueryRepositoryImpl.kt
+++ b/adapter-out/rdb/src/main/kotlin/com/yapp/bol/group/member/MemberQueryRepositoryImpl.kt
@@ -55,6 +55,7 @@ internal class MemberQueryRepositoryImpl(
         return memberRepository.findByGroupIdAndUserId(groupId.value, userId.value)?.toDomain()
     }
 
+    @Transactional(readOnly = true)
     override fun findOwner(groupId: GroupId): OwnerMember {
         val list = memberRepository.findByGroupIdAndRole(groupId.value, MemberRole.OWNER)
 
@@ -63,7 +64,8 @@ internal class MemberQueryRepositoryImpl(
         return list.first().toDomain() as OwnerMember
     }
 
+    @Transactional(readOnly = true)
     override fun getCount(groupId: GroupId): Int {
-        return memberRepository.count().toInt()
+        return memberRepository.countByGroupId(groupId.value).toInt()
     }
 }

--- a/adapter-out/rdb/src/main/kotlin/com/yapp/bol/group/member/MemberRepository.kt
+++ b/adapter-out/rdb/src/main/kotlin/com/yapp/bol/group/member/MemberRepository.kt
@@ -20,4 +20,6 @@ internal interface MemberRepository : JpaRepository<MemberEntity, Long>, CustomM
     fun findWithGameMember(groupId: Long): List<MemberEntity>
 
     fun findByGroupIdAndRole(groupId: Long, role: MemberRole): List<MemberEntity>
+
+    fun countByGroupId(groupId: Long): Long
 }


### PR DESCRIPTION
### Reference
- [Jira Ticket](https://yapp22-aos2.atlassian.net/browse/BOL-)

기존 count 쿼리가 member 테이블 전체 로우 수를 가져오고 있었어요.
memberRepository 에서 groupId 에 해당하는 row 들만 count 하도록 수정했습니다.

### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)  
